### PR TITLE
Nest template literal of startServer

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4,7 +4,7 @@ import { app } from "./app/app.js";
 
 export const startServer = (port: number) => {
   app.listen(port, () => {
-    console.log(`Listening on ${chalk.green(`http://localhost:${port}`)}`);
+    console.log("Listening on" + chalk.green("http://localhost:" + port));
   });
 };
 


### PR DESCRIPTION
He nesteado el templete literal de la función de startServer, corrigiendo así la maintainability issue que comenta sonar. 